### PR TITLE
add fuzz target

### DIFF
--- a/parser/fuzz/.gitignore
+++ b/parser/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/parser/fuzz/Cargo.toml
+++ b/parser/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+
+[package]
+name = "goscript-parser-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1.0", features = ["derive"] }
+
+[dependencies.goscript-parser]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "parse_file"
+path = "fuzz_targets/parse_file.rs"
+test = false
+doc = false

--- a/parser/fuzz/fuzz_targets/parse_file.rs
+++ b/parser/fuzz/fuzz_targets/parse_file.rs
@@ -1,0 +1,19 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use goscript_parser::errors::ErrorList;
+use goscript_parser::objects::Objects;
+use goscript_parser::{parse_file, FileSet};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    src: String,
+    trace: bool,
+}
+
+fuzz_target!(|input: Input| {
+    let mut fs = FileSet::new();
+    let o = &mut Objects::new();
+    let el = &mut ErrorList::new();
+    let _ = parse_file(o, &mut fs, el, "/a", &input.src, input.trace);
+});


### PR DESCRIPTION
I found that running a fuzz test on the parser uncovers some bugs. After installing [cargo-fuzz](https://rust-fuzz.github.io/book/cargo-fuzz.html), the target can be run with `cargo +nightly fuzz run parse_file`.