### PR TITLE
Octal integer improvements

### DIFF
--- a/types/src/constant.rs
+++ b/types/src/constant.rs
@@ -782,7 +782,7 @@ pub fn int_from_literal(lit: &str) -> Value {
     let result = if lit.starts_with("0x") {
         BigInt::from_str_radix(&lit[2..], 16)
     } else if lit.starts_with("0o") {
-        BigInt::from_str_radix(&lit[2..], 10)
+        BigInt::from_str_radix(&lit[2..], 8)
     } else if lit.starts_with("0b") {
         BigInt::from_str_radix(&lit[2..], 2)
     } else {


### PR DESCRIPTION
This PR aims to fix two problems with octal integers:
1. It fixes the radix notation for integer conversion.
2. It adds support for "bare" octal notation, e.g. `01`, `023` etc. Currently those numbers are treated as if they were decimals (`1`, `23`), whilst their decimal value is different (`1`, `27`). 

Also now integers such as `09` etc. throw lexer error, instead of being converted to decimals, as they should.