### PR TITLE
Create Map object from ffi context

### DIFF
--- a/vm/src/ffi.rs
+++ b/vm/src/ffi.rs
@@ -82,6 +82,11 @@ impl<'a> FfiCtx<'a> {
     }
 
     #[inline]
+    pub fn new_map(&self, map:MapObj) -> GosValue {
+        GosValue::new_map(self.gcc, map) 
+    }
+
+    #[inline]
     pub fn new_array(&self, member: Vec<GosValue>, t_elem: ValueType) -> GosValue {
         GosValue::array_with_data(member, self.array_slice_caller.get(t_elem), self.gcc)
     }

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -1489,8 +1489,8 @@ impl GosValue {
     }
 
     #[inline]
-    pub(crate) fn new_map(gcc: &GcContainer) -> GosValue {
-        let data = ValueData::new_map(MapObj::new(), gcc);
+    pub(crate) fn new_map(gcc: &GcContainer, obj:MapObj) -> GosValue {
+        let data = ValueData::new_map(obj, gcc);
         GosValue::new(ValueType::Map, data)
     }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -1569,7 +1569,7 @@ impl<'a> Fiber<'a> {
                                 GosValue::array_with_data(val, caller.get(typ), gcc)
                             }
                             MetadataType::Map(_, _) => {
-                                let map_val = GosValue::new_map(gcc);
+                                let map_val = GosValue::new_map(gcc, MapObj::new());
                                 let map = map_val.as_map().unwrap();
                                 for i in 0..count {
                                     let k = stack.get(begin + i * 2).clone();
@@ -1630,7 +1630,7 @@ impl<'a> Fiber<'a> {
                                     gcc,
                                 )
                             }
-                            MetadataType::Map(_, _) => GosValue::new_map(gcc),
+                            MetadataType::Map(_, _) => GosValue::new_map(gcc, MapObj::new()),
                             #[cfg(not(feature = "async"))]
                             MetadataType::Channel(_, _) => {
                                 go_panic_no_async!(panic, frame, code);


### PR DESCRIPTION
Fixes issue https://github.com/oxfeeefeee/goscript/issues/17#issue-1873535186

```rs
fn ffi_create_map(ctx:&FfiCtx) -> RuntimeResult<GosValue> {
    let mp = MapObj::new();
   Ok(ctx.new_map(mp)) // <= this is a map representation in Go
}
```